### PR TITLE
Fix TypeError by Adding Optional Chaining for Genres

### DIFF
--- a/app/series/[id]/page.tsx
+++ b/app/series/[id]/page.tsx
@@ -328,7 +328,7 @@ export default function SeriesDetailPage() {
               </div>
               
               <div className="mt-2 flex flex-wrap gap-2">
-                {series.genres.map(genreId => (
+                {series.genres?.map(genreId => (
                   <span 
                     key={genreId} 
                     className="px-3 py-1 bg-gray-700 text-xs rounded-full"
@@ -482,7 +482,7 @@ export default function SeriesDetailPage() {
                     )}
                     <li className="flex justify-between">
                       <span className="text-gray-400">Genres :</span>
-                      <span className="text-right">{series.genres.join(', ')}</span>
+                      <span className="text-right">{series.genres?.join(', ') || ''}</span>
                     </li>
                     {series.rating && (
                       <li className="flex justify-between">


### PR DESCRIPTION
This pull request addresses a runtime error caused by attempting to access the 'map' method on an undefined 'genres' property in the SeriesDetailPage component. The changes include:

1. Added optional chaining (`?.`) to safely access `series.genres` when mapping over it, preventing the TypeError if `genres` is undefined.
2. Updated the display of genres to use optional chaining and provide a fallback empty string if `genres` is undefined, ensuring the UI remains functional without crashing.

These changes enhance the robustness of the component by handling cases where the `genres` property may not be defined.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/zwzgnn3phtt8](https://cosine.sh/4ayarndg2r7x/StreamFlow/task/zwzgnn3phtt8)
Author: Neon
