### PR TITLE
Enhance Film Duplication Check in FilmModal

### DIFF
--- a/components/admin/films/FilmModal.tsx
+++ b/components/admin/films/FilmModal.tsx
@@ -698,9 +698,10 @@ export default function FilmModal({ open, onClose, onSave, initialData = {} }) {
                 if (dataCheck && dataCheck.length > 0) {
                   toast({
                     title: "Ce film existe déjà",
-                    description: `Un film avec ce titre et cette année est déjà présent dans votre base.`,
+                    description: `Un film avec ce titre et cette année est déjà présent dans la base. L'import a été annulé pour éviter un doublon.`,
                     variant: "destructive",
                   });
+                  // Ajout d'un retour visuel supplémentaire si besoin (par ex. secouer le bouton, etc.)
                   return;
                 }
               }


### PR DESCRIPTION
This pull request modifies the FilmModal component to improve the user experience when attempting to add a duplicate film. The error message displayed when a film with the same title and year already exists in the database has been updated for clarity. It now informs the user that the import has been canceled to prevent duplication. Additionally, a comment has been added to suggest implementing further visual feedback, such as shaking the button, to enhance user interaction. This change addresses the need for clearer communication regarding film duplication.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/yovlp89r00ag](https://cosine.sh/4ayarndg2r7x/StreamFlow/task/yovlp89r00ag)
Author: Neon
