### PR TITLE
Improve Film Duplication Warning in FilmModal

### DIFF
--- a/components/admin/films/FilmModal.tsx
+++ b/components/admin/films/FilmModal.tsx
@@ -697,8 +697,8 @@ export default function FilmModal({ open, onClose, onSave, initialData = {} }) {
                 }
                 if (dataCheck && dataCheck.length > 0) {
                   toast({
-                    title: "Ce film existe déjà",
-                    description: `Un film avec ce titre et cette année est déjà présent dans votre base.`,
+                    title: "Film déjà existant",
+                    description: "Ce film existe déjà dans la base. L'import a été annulé pour éviter un doublon.",
                     variant: "destructive",
                   });
                   return;


### PR DESCRIPTION
This pull request modifies the FilmModal component to enhance the user experience when adding films. The toast notification for existing films has been updated to provide clearer messaging. Instead of stating 'Ce film existe déjà' and 'Un film avec ce titre et cette année est déjà présent dans votre base.', the new message is 'Film déjà existant' and 'Ce film existe déjà dans la base. L'import a été annulé pour éviter un doublon.' This change aims to make the warning more concise and user-friendly, ensuring that users understand the reason for the import cancellation.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/yovlp89r00ag](https://cosine.sh/4ayarndg2r7x/StreamFlow/task/yovlp89r00ag)
Author: Neon
