### PR TITLE
Fix Type Error in Season Modal onSave Handler

### DIFF
--- a/app/admin/series/page.tsx
+++ b/app/admin/series/page.tsx
@@ -1,5 +1,16 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
+
+/**
+ * Represents the form values for creating or editing a season.
+ */
+interface SeasonFormValues {
+  id?: string;
+  season_number?: number | string | null;
+  tmdb_id?: number | string | null;
+  episode_count?: number | string | null;
+  [key: string]: any;
+}
 import Link from "next/link";
 import { Clapperboard as SeriesIcon, Plus, RefreshCw, ListTree } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -525,7 +536,7 @@ export default function AdminSeriesPage() {
       <SeasonModal
         open={modal.open && modal.type === "edit-season"}
         onClose={() => setModal({ open: false, type: "" })}
-        onSave={async (values) => {
+        onSave={async (values: SeasonFormValues) => {
           // Correction : typage strict et nettoyage pour l'édition
           const season_number = values.season_number ? Number(values.season_number) : null;
           const series_id = modal.parentId;
@@ -561,7 +572,7 @@ export default function AdminSeriesPage() {
       <SeasonModal
         open={modal.open && modal.type === "add-season"}
         onClose={() => setModal({ open: false, type: "" })}
-        onSave={async (values) => {
+        onSave={async (values: SeasonFormValues) => {
           // Correction : typage strict et nettoyage pour l'ajout
           const season_number = values.season_number ? Number(values.season_number) : null;
           const series_id = modal.parentId;


### PR DESCRIPTION
This pull request addresses a type error in the `AdminSeriesPage` component related to the `onSave` handler of the `SeasonModal`. The parameter `values` was previously implicitly typed as 'any', which caused the build to fail. 

To resolve this, I introduced a new interface `SeasonFormValues` that defines the expected structure of the `values` parameter. This ensures type safety and prevents similar issues in the future. 

The changes were made in `app/admin/series/page.tsx`, specifically in the `onSave` function for both the 'edit-season' and 'add-season' modals. The build should now compile successfully.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/t1t65ovl56a3](https://cosine.sh/4ayarndg2r7x/StreamFlow/task/t1t65ovl56a3)
Author: Neon
