### PR TITLE
Fix Type Error in AdminSeriesPage Component

### DIFF
--- a/app/admin/series/page.tsx
+++ b/app/admin/series/page.tsx
@@ -606,17 +606,17 @@ export default function AdminSeriesPage() {
       <EpisodeModal
         open={modal.open && modal.type === "edit-episode"}
         onClose={() => setModal({ open: false, type: "" })}
-        onSubmit={async (values) => {
+        onSave={async (values) => {
           await supabase.from("episodes").update(values).eq("id", values.id);
           if (modal.parentId) {/* refresh episodes */}
         }}
-        initial={modal.payload}
+        initialData={modal.payload}
         seasonId={modal.parentId}
       />
       <EpisodeModal
         open={modal.open && modal.type === "add-episode"}
         onClose={() => setModal({ open: false, type: "" })}
-        onSubmit={async (values) => {
+        onSave={async (values) => {
           // S'assurer que series_id est injecté dans l'épisode ajouté
           const series_id = modal.payload && modal.payload.seriesId
             ? modal.payload.seriesId


### PR DESCRIPTION
This pull request addresses a type error in the `AdminSeriesPage` component located in `app/admin/series/page.tsx`. The error occurred because the property `initial` was not defined in the expected props for the component. 

To resolve this, the property `initial` has been renamed to `initialData`, which aligns with the expected prop types. This change ensures that the component compiles successfully and adheres to the defined TypeScript types, allowing for a successful build of the application.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/yednydjhsxhi](https://cosine.sh/4ayarndg2r7x/StreamFlow/task/yednydjhsxhi)
Author: Neon
