### PR TITLE
Fix ReferenceError by Defining Subtitle in ContentSection

### DIFF
--- a/components/content-section.tsx
+++ b/components/content-section.tsx
@@ -32,6 +32,7 @@ type SectionType = 'popular_movies' | 'popular_series' | 'movies_by_genre' | 'se
 
 interface ContentSectionProps {
   title: string;
+  subtitle?: string;
   viewAllLink?: string;
   className?: string;
   children?: React.ReactNode;
@@ -43,6 +44,7 @@ interface ContentSectionProps {
 
 export function ContentSection({
   title,
+  subtitle,
   viewAllLink,
   className = '',
   children,
@@ -208,7 +210,12 @@ export function ContentSection({
   return (
     <section className={`mb-8 ${className}`}>
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-bold">{title}</h2>
+        <div>
+          <h2 className="text-xl font-bold">{title}</h2>
+          {subtitle && (
+            <p className="text-gray-400 text-sm mt-1">{subtitle}</p>
+          )}
+        </div>
         {!hideViewAllButton && (
           <Link
             href={


### PR DESCRIPTION
This pull request addresses the ReferenceError encountered in the ContentSection component due to the undefined 'subtitle' variable. The changes include:

- Added an optional 'subtitle' prop to the ContentSectionProps interface.
- Updated the ContentSection function to accept the 'subtitle' prop.
- Modified the JSX to conditionally render the subtitle if it is provided.

These changes ensure that the subtitle can be displayed correctly without causing errors, improving the component's robustness.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/monrrnho9bhf](https://cosine.sh/4ayarndg2r7x/StreamFlow/task/monrrnho9bhf)
Author: Neon
