### PR TITLE
Add Footer to Watch Film and Episode Pages

### DIFF
--- a/app/films/[id]/watch/page.tsx
+++ b/app/films/[id]/watch/page.tsx
@@ -12,6 +12,7 @@ import SimilarMoviesGrid from "@/components/SimilarMoviesGrid";
 import { supabase } from "@/lib/supabaseClient";
 import { getTMDBImageUrl } from "@/lib/tmdb";
 import { ArrowLeft } from "lucide-react";
+import Footer from "@/components/footer";
 
 function normalizeBackdropUrl(raw: string | undefined) {
   if (typeof raw === "string" && raw.trim().length > 0) {
@@ -224,6 +225,10 @@ export default function WatchFilmPage() {
           animation: fadeInUp 0.6s cubic-bezier(.23,1.02,.25,1) both;
         }
       `}</style>
+    {/* Footer */}
+        <div className="w-full mt-8">
+          <Footer />
+        </div>
     </div>
   );
 }

--- a/app/series/[id]/watch/[episodeId]/page.tsx
+++ b/app/series/[id]/watch/[episodeId]/page.tsx
@@ -10,6 +10,7 @@ import LoadingScreen from "@/components/loading-screen";
 import SeasonModalUser from "@/components/series/SeasonModalUser";
 import { supabase } from "@/lib/supabaseClient";
 import { ChevronLeft, ListPlus } from "lucide-react";
+import Footer from "@/components/footer";
 
 type Episode = {
   id: string;
@@ -427,6 +428,10 @@ export default function WatchEpisodePage() {
           animation: fadeInUp 0.6s cubic-bezier(.23,1.02,.25,1) both;
         }
       `}</style>
+      {/* Footer */}
+      <div className="w-full mt-8">
+        <Footer />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This pull request restores the footer component in both the film and episode watch pages. The footer was missing, which could affect the user experience by not providing necessary navigation and information at the bottom of the pages. 

### Changes Made:
- Imported the `Footer` component in `app/films/[id]/watch/page.tsx` and `app/series/[id]/watch/[episodeId]/page.tsx`.
- Added the `Footer` component to the JSX structure of both pages, ensuring it appears below the main content.

These changes enhance the overall layout and usability of the watch pages.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/x8xxaa3mv4x2](https://cosine.sh/4ayarndg2r7x/StreamFlow/task/x8xxaa3mv4x2)
Author: Neon
