### PR TITLE
Fix Supabase Client Initialization and Update Manifest

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,11 +39,14 @@ export const metadata: Metadata = {
       { rel: 'icon', url: '/logo-icon.svg', type: 'image/svg+xml' }
     ],
   },
-  appleWebApp: {
-    capable: true,
-    title: "StreamFlow",
-    statusBarStyle: "default",
-  },
+  other: [
+    { name: "mobile-web-app-capable", content: "yes" }
+  ],
+  // appleWebApp: {
+  //   capable: true,
+  //   title: "StreamFlow",
+  //   statusBarStyle: "default",
+  // },
   openGraph: {
     title: "StreamFlow - Plateforme de streaming Films et Séries",
     description: "Regardez des films et séries en ligne sur StreamFlow.",

--- a/lib/initSupabase.ts
+++ b/lib/initSupabase.ts
@@ -3,4 +3,20 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+let supabase: ReturnType<typeof createClient> | undefined = undefined;
+
+// Singleton pattern to avoid multiple clients in the same browser context
+if (typeof window !== 'undefined') {
+  // @ts-ignore
+  if (!window.__supabase) {
+    // @ts-ignore
+    window.__supabase = createClient(supabaseUrl, supabaseAnonKey);
+  }
+  // @ts-ignore
+  supabase = window.__supabase;
+} else {
+  // SSR fallback
+  supabase = createClient(supabaseUrl, supabaseAnonKey);
+}
+
+export { supabase };

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,61 +15,13 @@
   "iarc_rating_id": "e84b072d-71b3-4d3e-86ae-31a8ce4e53b7",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
-      "sizes": "72x72",
-      "type": "image/png",
+      "src": "/logo-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
       "purpose": "any"
     },
     {
-      "src": "/icons/icon-96x96.png",
-      "sizes": "96x96",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-384x384.png",
-      "sizes": "384x384",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/maskable-icon.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/StreamFlow.svg",
+      "src": "/logo.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any maskable"


### PR DESCRIPTION
This pull request addresses multiple issues related to the Supabase client initialization and updates the web app manifest. 

### Changes Made:
1. **Supabase Client Initialization**: Modified `initSupabase.ts` to implement a singleton pattern for the Supabase client. This prevents multiple instances of `GoTrueClient` from being created in the same browser context, which was causing warnings in the console.
2. **Manifest Updates**: Updated `manifest.json` to replace deprecated meta tags and ensure the correct icons are referenced. Removed unused icon entries and added a reference to the logo icon.
3. **Layout Metadata**: Adjusted `layout.tsx` to remove deprecated Apple Web App settings and replace them with the appropriate mobile web app capable meta tag.

These changes improve the application's performance and resolve the warnings related to multiple Supabase client instances.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/yce89p923zyt](https://cosine.sh/rwpbveiulrul/StreamFlow/task/yce89p923zyt)
Author: Cheikh Gadji
