### PR TITLE
Update Uqload URL Validation in FilmModal

### DIFF
--- a/components/admin/films/FilmModal.tsx
+++ b/components/admin/films/FilmModal.tsx
@@ -205,7 +205,7 @@ export default function FilmModal({ open, onClose, onSave, initialData = {} }: F
     // Validation spécifique par plateforme
     if (form.streamtape_url && !/^https?:\/\/(www\.)?streamtape\.com\//.test(form.streamtape_url))
       err.streamtape_url = "Lien Streamtape invalide";
-    if (form.uqload_url && !/^https?:\/\/(www\.)?uqload\.(io|net)\//.test(form.uqload_url))
+    if (form.uqload_url && !/^https?:\/\/(www\.)?uqload\.(io|net|com)\//.test(form.uqload_url))
       err.uqload_url = "Lien Uqload invalide";
 
     return err;


### PR DESCRIPTION
This pull request modifies the URL validation logic in the FilmModal component. Specifically, it updates the regular expression used to validate the Uqload URL to allow for the '.com' domain in addition to the existing '.io' and '.net' domains. This change ensures that valid Uqload links with the '.com' domain are accepted, improving the user experience by reducing validation errors for legitimate URLs.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/pbisrzm58cdm](https://cosine.sh/rwpbveiulrul/StreamFlow/task/pbisrzm58cdm)
Author: Cheikh Gadji
