### PR TITLE
Update Series Display on Homepage

### DIFF
--- a/components/content-section.tsx
+++ b/components/content-section.tsx
@@ -215,10 +215,8 @@ export function ContentSection({
               `}>{item.title}</h3>
               <p className="text-[11px] text-gray-400 w-full text-center">
                 {isMovie
-                  ? (item as Movie).year
-                  : `${(item as Series).startYear ?? ''}${
-                      (item as Series).endYear ? ` - ${(item as Series).endYear}` : ''
-                    }`}
+                  ? (item as Movie).year ?? ''
+                  : (item as Series).startYear ?? ''}
               </p>
             </div>
           </Link>


### PR DESCRIPTION
This pull request modifies the content section of the homepage to improve the display of series information. Specifically, it updates the rendering logic for series years to only show the start year, removing the end year from the display. This change simplifies the information presented to users and ensures consistency in how movie and series years are displayed.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/qjtkqw0vvcwm](https://cosine.sh/rwpbveiulrul/StreamFlow/task/qjtkqw0vvcwm)
Author: Cheikh Gadji
