### PR TITLE
Fix reset password page by adding Suspense boundary

### DIFF
--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/use-toast';
 
-export default function ResetPasswordPage() {
+function ResetPasswordPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
@@ -121,5 +121,19 @@ export default function ResetPasswordPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-900 py-12 px-4">
+        <div className="max-w-md w-full bg-gray-800 rounded-lg shadow-lg p-8 text-white text-center">
+          Chargement de la page de réinitialisation...
+        </div>
+      </div>
+    }>
+      <ResetPasswordPageInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
This pull request addresses the issue encountered during the build process related to the `/reset-password` page. The error indicated that `useSearchParams()` should be wrapped in a suspense boundary. 

To resolve this, I have modified the `ResetPasswordPage` component to include a `Suspense` wrapper around the inner component. This change ensures that the page can handle loading states properly, preventing the prerendering error that was previously occurring. 

With this update, the reset password page should now function correctly during the build process.

---

> This pull request was co-created with Cosine Genie

Original Task: [StreamFlow/mozpxblknge7](https://cosine.sh/rwpbveiulrul/StreamFlow/task/mozpxblknge7)
Author: Cheikh Gadji
